### PR TITLE
Simplify info bezel css

### DIFF
--- a/docs/_data/photos/Unsplash_E_LsevHWTBE.json
+++ b/docs/_data/photos/Unsplash_E_LsevHWTBE.json
@@ -1,0 +1,27 @@
+{
+  "id": "08014ea8-cf2f-45c6-825d-15be6c4c803e",
+  "url": "https://images.unsplash.com/photo-1530435622277-39544076a5f8?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&ixid=eyJhcHBfaWQiOjQyOTgyfQ",
+  "external_url": "https://unsplash.com/photos/E_LsevHWTBE",
+  "content_text": "running red and white train in the subway",
+  "_meta": {
+    "venue": {
+      "name": "Unsplash",
+      "url": "https://unsplash.com"
+    },
+    "camera": {
+      "iso": 320,
+      "shutter_speed": "1/30",
+      "aperture": "3.6",
+      "make": "FUJIFILM",
+      "model": "X-T2"
+    }
+  },
+  "author": {
+    "name": "paucasals",
+    "url": "https://unsplash.com/@paucasals",
+    "avatar": "https://images.unsplash.com/profile-1520435330198-528ac198e267?ixlib=rb-1.2.1&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=32&w=32"
+  },
+  "tags": [
+
+  ]
+}

--- a/web_extension/content/new_tab.html
+++ b/web_extension/content/new_tab.html
@@ -20,16 +20,19 @@
   <body>
     <background></background>
     <prefetch></prefetch>
-    <sidebar class='bezel'>
+    <sidebar class="subtle">
       <clock>
         <time></time>
         <date></date>
       </clock>
 
-      <info class="hide">
+      <info>
         <name></name>
+        <br>
         <by-line></by-line>
+        <br>
         <venue></venue>
+        <br>
         <camera></camera>
       </info>
     </sidebar>

--- a/web_extension/content/scripts/new_tab.js
+++ b/web_extension/content/scripts/new_tab.js
@@ -101,11 +101,8 @@ function tick() {
 }
 
 async function set_bezel_persistence(){
-  document.querySelector('clock').classList.remove('subtle', 'aggressive', 'demanding')
-  document.querySelector('info').classList.remove('subtle', 'aggressive', 'demanding')
-
-  document.querySelector('clock').classList.add(display_options.clock_persistence.toLowerCase())
-  document.querySelector('info').classList.add(display_options.info_persistence.toLowerCase())
+  document.querySelector('sidebar').classList.remove('subtle', 'aggressive', 'demanding')
+  document.querySelector('sidebar').classList.add(display_options.info_persistence.toLowerCase())
 }
 
 

--- a/web_extension/content/styles/clock.css
+++ b/web_extension/content/styles/clock.css
@@ -1,13 +1,3 @@
-sidebar {
-  position: absolute;
-  top: 0;
-  left: 0;
-
-  overflow: hidden;
-  padding: 0 1em;
-
-  display: table-row;
-}
 
 clock {
   text-align: center;
@@ -23,7 +13,6 @@ clock.top_border date {
 
 clock, info {
   padding: 0.5em 0.5em 0.5em 0.5em;
-  display: table-cell;
 }
 
 time {
@@ -51,7 +40,6 @@ by-line, camera, name, venue {
 }
 
 name { font-weight: 400 }
-by-line { display: none }
 
 camera {
   display: grid;

--- a/web_extension/content/styles/main.css
+++ b/web_extension/content/styles/main.css
@@ -62,41 +62,43 @@ version {
   cursor: default;
 }
 
-.bezel {
+sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  padding: 0 1em;
+  display: flex;
+  align-items: center;
+
+  transition: all 1800ms ease-out;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 200;
-  border-width: 0;
-  transition: all 3s ease-out;
 
-  color: var(--text-color-subtle);
-  border-color: rgba(250, 250, 250, 0.1);
-  background-color: rgba(17, 17, 17, 0.0);
-}
-
-.bezel .hide {
-  color: rgba(250, 250, 250, 0);
-  transition: all 900ms ease-out;
-}
-
-.bezel .aggressive {
   color: rgba(250, 250, 250, 1);
 }
 
-.bezel .demanding {
+sidebar.subtle {
+  background-color: rgba(17, 17, 17, 0);
+  color: rgba(250, 250, 250, 0.2);
+}
+
+sidebar.aggressive {
+  color: rgba(250, 250, 250, 1);
+}
+
+sidebar.demanding {
   color: rgba(250, 250, 250, 1);
   background-color: rgba(17, 17, 17, 0.8);
 }
 
-.bezel:hover {
-  transition: all 900ms ease-out;
-}
+sidebar:hover { transition: all 700ms ease-out; }
 
-.bezel:hover {
+sidebar:hover.subtle {
   color: rgba(250, 250, 250, 1);
-  border-color: rgba(250, 250, 250, 1);
   background-color: rgba(17, 17, 17, 0.8);
 }
 
-.bezel:hover .hide {
-  color: rgba(250, 250, 250, 1);
+sidebar:hover.aggressive {
+  background-color: rgba(17, 17, 17, 0.8);
 }

--- a/web_extension/content/styles/main.css
+++ b/web_extension/content/styles/main.css
@@ -33,7 +33,7 @@ prefetch {
   position: absolute;
   bottom: 0;
   right: 100px;
-
+  visibility: hidden;
 }
 
 prefetch img {
@@ -43,6 +43,7 @@ prefetch img {
 
 .show_cache prefetch {
   z-index: 10;
+  visibility: visible;
 }
 
 .show_cache prefetch img {

--- a/web_extension/options/options.html
+++ b/web_extension/options/options.html
@@ -11,15 +11,22 @@
     <form>
 
       <fieldset>
-        <legend>Clock</legend>
+        <legend>Info</legend>
 
         <label>
           Persistence
-          <select id="clock_persistence" data-namespace="display">
+          <select id="info_persistence" data-namespace="display">
             <option>Subtle</option>
             <option>Aggressive</option>
             <option>Demanding</option>
           </select>
+        </label>
+
+        <br>
+
+        <label>
+          <input type="checkbox" id="show_info" data-namespace="display">
+          Available metadata
         </label>
 
         <br>
@@ -51,26 +58,6 @@
             <option value="good">2018-10-22</option>
             <option value="bad">October 22, 2018</option>
           </select>
-        </label>
-      </fieldset>
-
-      <fieldset>
-        <legend>Info</legend>
-
-        <label>
-          Persistence
-          <select id="info_persistence" data-namespace="display">
-            <option>Subtle</option>
-            <option>Aggressive</option>
-            <option>Demanding</option>
-          </select>
-        </label>
-
-        <br>
-
-        <label>
-          <input type="checkbox" id="show_info" data-namespace="display">
-          Image info
         </label>
       </fieldset>
 

--- a/web_extension/shared/options.js
+++ b/web_extension/shared/options.js
@@ -63,7 +63,6 @@ class DisplayOptions extends OptionsSubset {
     this.show_info = true
 
     this.twentyfour_hour_clock = true
-    this.clock_persistence = "Subtle"
     this.info_persistence = "Subtle"
     this.clock_flash = false
     this.date_format = "good"


### PR DESCRIPTION
- Simplifies info bezel css/html.
- fixes bug where the prefetch div is visible in the bottom right 🤷‍♂️ 

New options removes individual options for display for both info and clock, and unifies them:

<img width="148" alt="image" src="https://user-images.githubusercontent.com/208647/49891250-4f160400-fe03-11e8-9299-4072064ed16e.png">
